### PR TITLE
Added ability to set to_ext when downloading dataset

### DIFF
--- a/src/main/java/com/github/jmchilton/blend4j/galaxy/HistoriesClientImpl.java
+++ b/src/main/java/com/github/jmchilton/blend4j/galaxy/HistoriesClientImpl.java
@@ -111,8 +111,12 @@ class HistoriesClientImpl extends Client implements HistoriesClient {
   @Override
   public void downloadDataset(String historyId, String datasetId,
       File destinationFile) throws IOException {
+	Dataset dataset = showDataset(historyId, datasetId);
+	String fileExt = dataset.getDataTypeExt();
+	
     File downloadedFile = super.getWebResourceContents(historyId)
-        .path(datasetId).path("display").get(File.class);
+        .path(datasetId).path("display").queryParam("to_ext", fileExt)
+        .get(File.class);
     downloadedFile.renameTo(destinationFile);
     FileWriter fr = new FileWriter(downloadedFile);
     fr.close();


### PR DESCRIPTION
This fixes an issue when downloading datasets.  Before this fix, the request sent was:

```
GET /api/histories/[history_id]/contents/[dataset_id]/display?key=[api key]
```

However, after this fix the request is:

```
GET /api/histories/[history_id]/contents/[dataset_id]/display?key=[api key]&to_ext=[extension]
```

This is, it adds on the `to_ext` parameter.  This mimics the behaviour in bioblend https://github.com/galaxyproject/bioblend/blob/v0.5.3/bioblend/galaxy/datasets/__init__.py#L95.